### PR TITLE
Gitinfo2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,50 @@
 TARGET=paper
+GIT_HOOKS_DIR=.git/hooks
+POST_CHECKOUT_FILE=$(GIT_HOOKS_DIR)/post-checkout
 all: pdf
 
-pdf:
+define POST_CHECKOUT_CMD =
+#!/bin/sh
+# Copyright 2014 Brent Longborough
+# Part of gitinfo2 package Version 2
+# Please read gitinfo2.pdf for licencing and other details
+# -----------------------------------------------------
+# Post-{commit,checkout,merge} hook for the gitinfo2 package
+#
+# Get the first tag found in the history from the current HEAD
+FIRSTTAG=$(git describe --tags --always --dirty='-*' 2>/dev/null)
+# Get the first tag in history that looks like a Release
+RELTAG=$(git describe --tags --long --always --dirty='-*' --match '[0-9]*.*' 2>/dev/null)
+# Hoover up the metadata
+git --no-pager log -1 --date=short --decorate=short \
+    --pretty=format:"\usepackage[%
+        shash={%h},
+        lhash={%H},
+        authname={%an},
+        authemail={%ae},
+        authsdate={%ad},
+        authidate={%ai},
+        authudate={%at},
+        commname={%an},
+        commemail={%ae},
+        commsdate={%ad},
+        commidate={%ai},
+        commudate={%at},
+        refnames={%d},
+        firsttagdescribe={$FIRSTTAG},
+        reltag={$RELTAG}
+    ]{gitexinfo}" HEAD > .git/gitHeadInfo.gin
+endef
+export POST_CHECKOUT_CMD
+
+setup-gitinfo2:
+ifneq ("$(wildcard $(GIT_HOOKS_DIR))","")
+	@echo "$$POST_CHECKOUT_CMD" > $(POST_CHECKOUT_FILE)
+	@chmod +x $(POST_CHECKOUT_FILE)
+	@$(POST_CHECKOUT_FILE)
+endif
+
+pdf: setup-gitinfo2
 	GS_OPTIONS=-dPDFSETTINGS=/prepress rubber -f --pdf -Wrefs -Wmisc $(TARGET)
 
 clean:

--- a/confpaper.cls
+++ b/confpaper.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{confpaper}[2014/6/17 conference paper latex class]
 
-%%% Opitons
+%%% Options
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{extarticle}}
 
 %%% Process given options

--- a/confpaper.cls
+++ b/confpaper.cls
@@ -23,6 +23,7 @@
 \newcommand{\CONFERENCE}{Conference}
 \newcommand{\PAGENUMBERS}{yes} % "yes" or "no"
 \newcommand{\COLOR}{yes}
+\newcommand{\GITINFO}{no}
 \newcommand{\showComments}{yes}
 \newcommand{\comment}[1]{}
 \newcommand{\onlyAbstract}{no}
@@ -171,6 +172,11 @@
   \pagestyle{plain}
 }{%
   \pagestyle{empty}
+}
+
+\ifthenelse{\equal{\GITINFO}{yes}}{%
+\RequirePackage[mark]{gitinfo2}
+}{%
 }
 
 %%%


### PR DESCRIPTION
It works for me on Linux, but you should also test it on a Mac.

Also, the commit includes a copyrighted shell script by Brent Longborough. The licensing info is:

```
Copyright & licence
Copyright © 2014, Brent Longborough, who has asserted his moral right to
be identified as the author of this work.
This work — gitinfo2 — may be distributed and/or modified under the
conditions of the LaTeX Project Public License: either version 1.3 of this license,
or (at your option) any later version.
The latest version of this license can be found at the LATEX Project website,7
and version 1.3 or later is part of all recent distributions of LATEX.
This work has the LPPL maintenance status ‘maintained’; the Current
Maintainer of this work is Brent Longborough.
This work consists of the files gitinfo2.sty, gitexinfo.sty, gitinfo2.tex, gitinfo2.pdf,
gitinfotest.tex, post-xxx-sample.txt, and gitPseudoHeadInfo.gin.
```

It's a free software license but I'm not enough of a license specialist to be sure that the way I included the script is OK.
